### PR TITLE
Rename UnitsDefinition property to match Python SDK

### DIFF
--- a/schema/enum_int.go
+++ b/schema/enum_int.go
@@ -21,7 +21,7 @@ type IntEnum interface {
 // IntEnumSchema is an enum type with integer values.
 type IntEnumSchema struct {
 	EnumSchema[int64] `json:",inline"`
-	IntUnits          *UnitsDefinition `json:"UnitsDefinition"`
+	IntUnits          *UnitsDefinition `json:"units"`
 }
 
 func (i IntEnumSchema) TypeID() TypeID {

--- a/schema/float.go
+++ b/schema/float.go
@@ -29,7 +29,7 @@ func NewFloatSchema(min *float64, max *float64, units *UnitsDefinition) *FloatSc
 type FloatSchema struct {
 	MinValue   *float64         `json:"min"`
 	MaxValue   *float64         `json:"max"`
-	UnitsValue *UnitsDefinition `json:"UnitsDefinition"`
+	UnitsValue *UnitsDefinition `json:"units"`
 }
 
 func (f FloatSchema) ReflectedType() reflect.Type {

--- a/schema/int.go
+++ b/schema/int.go
@@ -28,7 +28,7 @@ func NewIntSchema(min *int64, max *int64, units *UnitsDefinition) *IntSchema {
 type IntSchema struct {
 	MinValue   *int64           `json:"min"`
 	MaxValue   *int64           `json:"max"`
-	UnitsValue *UnitsDefinition `json:"UnitsDefinition"`
+	UnitsValue *UnitsDefinition `json:"units"`
 }
 
 func (i IntSchema) ReflectedType() reflect.Type {

--- a/schema/ref.go
+++ b/schema/ref.go
@@ -82,11 +82,12 @@ func (r *RefSchema) Display() Display {
 }
 
 func (r *RefSchema) ApplyScope(scope Scope) {
+
 	objects := scope.Objects()
 	referencedObject, ok := objects[r.IDValue]
 	if !ok {
 		panic(BadArgumentError{
-			Message: fmt.Sprintf("Referenced object %s not found in scope", r.IDValue),
+			Message: fmt.Sprintf("Referenced object '%s' not found in scope", r.IDValue),
 		})
 	}
 	r.referencedObjectCache = referencedObject

--- a/schema/schema_schema.go
+++ b/schema/schema_schema.go
@@ -314,7 +314,7 @@ var basicObjects = []*ObjectSchema{
 			nil,
 			[]string{"16.0"},
 		),
-		"UnitsDefinition": unitsProperty,
+		"units": unitsProperty,
 	}),
 	NewStructMappedObjectSchema[*IntEnumSchema]("IntEnum", map[string]*PropertySchema{
 		"values": NewPropertySchema(
@@ -339,7 +339,7 @@ var basicObjects = []*ObjectSchema{
 			nil,
 			[]string{"{\"1024\": {\"name\": \"kB\"}, \"1048576\": {\"name\": \"MB\"}}"},
 		),
-		"UnitsDefinition": unitsProperty,
+		"units": unitsProperty,
 	}),
 	NewStructMappedObjectSchema[*IntSchema](
 		"Int",
@@ -372,7 +372,7 @@ var basicObjects = []*ObjectSchema{
 				nil,
 				[]string{"16"},
 			),
-			"UnitsDefinition": unitsProperty,
+			"units": unitsProperty,
 		},
 	),
 	NewStructMappedObjectSchema[*ListSchema](


### PR DESCRIPTION
Closes #20 

## Changes introduced with this PR

This changes the units property name to match the Python SDK. This will make it compatible with the output of the Python SDK.

If testing this, the existing Go plugins that use the UnitsProperty will fail.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).