### PR TITLE
Hard Code version of golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52.2
   test:
     name: go test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes introduced with this PR

I have found problems in the engine and ACT for using the goalngci-lint action. This version has fixed the same build times error I see in the recent PR's.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).