### PR TITLE
Improve termination handling

### DIFF
--- a/atp/protocol.go
+++ b/atp/protocol.go
@@ -1,11 +1,11 @@
 package atp
 
-type helloMessage struct {
+type HelloMessage struct {
 	Version int64 `cbor:"version"`
 	Schema  any   `cbor:"schema"`
 }
 
-type startWorkMessage struct {
+type StartWorkMessage struct {
 	StepID string `cbor:"id"`
 	Config any    `cbor:"config"`
 }

--- a/atp/protocol_test.go
+++ b/atp/protocol_test.go
@@ -22,7 +22,7 @@ type helloWorldOutput struct {
 	Message string `json:"message"`
 }
 
-func helloWorldHandler(input helloWorldInput) (string, any) {
+func helloWorldHandler(_ context.Context, input helloWorldInput) (string, any) {
 	return "success", helloWorldOutput{
 		Message: fmt.Sprintf("Hello, %s!", input.Name),
 	}

--- a/atp/protocol_test.go
+++ b/atp/protocol_test.go
@@ -3,13 +3,15 @@ package atp_test
 import (
 	"context"
 	"fmt"
-	"io"
+	"github.com/fxamacker/cbor/v2"
 	"sync"
-	"testing"
 
-	log "go.arcalot.io/log/v2"
+	"go.arcalot.io/assert"
+	"go.arcalot.io/log/v2"
 	"go.flow.arcalot.io/pluginsdk/atp"
 	"go.flow.arcalot.io/pluginsdk/schema"
+	"io"
+	"testing"
 )
 
 type helloWorldInput struct {
@@ -86,57 +88,468 @@ func (c channel) Close() error {
 	return nil
 }
 
-func TestProtocol(t *testing.T) {
+func TestProtocol_Client_Execute(t *testing.T) {
+	// Client ReadSchema and Execute happy path.
+	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var testError error
 
 	go func() {
 		defer wg.Done()
-		defer cancel()
-
-		if err := atp.RunATPServer(
+		assert.NoError(t, atp.RunATPServer(
 			ctx,
 			stdinReader,
 			stdoutWriter,
 			helloWorldSchema,
-		); err != nil {
-			testError = err
-		}
+		))
 	}()
+
 	go func() {
 		defer wg.Done()
-		defer cancel()
-
 		cli := atp.NewClientWithLogger(channel{
 			Reader:  stdoutReader,
 			Writer:  stdinWriter,
-			Context: ctx,
+			Context: nil,
 			cancel:  cancel,
 		}, log.NewTestLogger(t))
 
 		_, err := cli.ReadSchema()
+		assert.NoError(t, err)
+
+		outputID, outputData, err := cli.Execute(ctx, "hello-world", map[string]any{"name": "Arca Lot"})
+		assert.NoError(t, err)
+		assert.Equals(t, outputID, "success")
+		assert.Equals(t, outputData.(map[any]any)["message"].(string), "Hello, Arca Lot!")
+	}()
+
+	wg.Wait()
+}
+
+func TestProtocol_Client_ReadSchema(t *testing.T) {
+	// Client ReadSchema happy path.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, atp.RunATPServer(
+			ctx,
+			stdinReader,
+			stdoutWriter,
+			helloWorldSchema,
+		))
+	}()
+
+	go func() {
+		// terminate the protocol execution
+		// because it will not be completed
+		defer cancel()
+		defer wg.Done()
+		cli := atp.NewClientWithLogger(channel{
+			Reader:  stdoutReader,
+			Writer:  stdinWriter,
+			Context: nil,
+			cancel:  cancel,
+		}, log.NewTestLogger(t))
+		_, err := cli.ReadSchema()
+		assert.NoError(t, err)
+	}()
+
+	wg.Wait()
+}
+
+func TestProtocol_Error_Client_StartOutput(t *testing.T) {
+	// Induce error on client's encoding of start output message
+	// by closing the client's cbor encoder's io pipe, stdinWriter.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	_, stdinWriter := io.Pipe()
+	stdoutReader, _ := io.Pipe()
+	defer cancel()
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	// close client's cbor encoder's io pipe
+	assert.NoError(t, stdinWriter.Close())
+
+	go func() {
+		defer wg.Done()
+		_, err := cli.ReadSchema()
+		assert.Error(t, err)
+	}()
+
+	wg.Wait()
+}
+
+func TestProtocol_Error_Server_StartOutput(t *testing.T) {
+	// Induce error on server's decoding of start output message
+	// by closing the server's cbor decoder's io pipe, stdinReader.
+	stdinReader, _ := io.Pipe()
+	_, stdoutWriter := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// close the server's cbor decoder's io pipe
+	assert.NoError(t, stdinReader.Close())
+
+	err := atp.RunATPServer(
+		ctx,
+		stdinReader,
+		stdoutWriter,
+		helloWorldSchema,
+	)
+
+	assert.Error(t, err)
+}
+
+func TestProtocol_Error_Client_Hello(t *testing.T) {
+	// Induce error at client's decoding of hello message
+	// by closing the client's cbor decoder's io pipe,
+	// stdoutReader.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	srvr := newATPServer(channel{
+		Reader:  stdinReader,
+		Writer:  stdoutWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	// close client's cbor decoder's io pipe
+	assert.NoError(t, stdoutReader.Close())
+
+	go func() {
+		defer wg.Done()
+		_, err := cli.ReadSchema()
+		assert.Error(t, err)
+	}()
+
+	var empty any
+	assert.NoError(t, srvr.decoder.Decode(&empty))
+
+	wg.Wait()
+}
+
+func TestProtocol_Error_Server_Hello(t *testing.T) {
+	// Induce error on server's encoding of the hello message
+	// by closing the server's cbor encoder's io pipe.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	wgcli := &sync.WaitGroup{}
+	wgcli.Add(1)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	var test_error error
+
+	go func() {
+		defer wg.Done()
+		err := atp.RunATPServer(
+			ctx,
+			stdinReader,
+			stdoutWriter,
+			helloWorldSchema,
+		)
+
 		if err != nil {
-			testError = err
-			return
-		}
-		outputID, outputData, _ := cli.Execute(ctx, "hello-world", map[string]any{"name": "Arca Lot"})
-		if outputID != "success" {
-			testError = fmt.Errorf("Invalid output ID: %s", outputID)
-			return
-		}
-		if outputMessage := outputData.(map[any]any)["message"].(string); outputMessage != "Hello, Arca Lot!" {
-			testError = fmt.Errorf("Invalid output message: %s", outputMessage)
-			return
+			test_error = err
 		}
 	}()
+
+	go func() {
+		defer wgcli.Done()
+		assert.NoError(t, cli.Encoder().Encode(nil))
+
+		// close server's cbor encoder's io pipe
+		assert.NoError(t, stdoutWriter.Close())
+	}()
+	wgcli.Wait()
+
 	wg.Wait()
-	if testError != nil {
-		t.Fatal(testError)
+	assert.Error(t, test_error)
+}
+
+func TestProtocol_Error_Server_WorkStart(t *testing.T) {
+	// Induce error on server's decoding of the start work
+	// message by closing the server's cbor decoder's
+	// io pipe.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	var test_error error
+	go func() {
+		defer wg.Done()
+		err := atp.RunATPServer(
+			ctx,
+			stdinReader,
+			stdoutWriter,
+			helloWorldSchema,
+		)
+
+		if err != nil {
+			test_error = err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, cli.Encoder().Encode(nil))
+		var hello atp.HelloMessage
+		assert.NoError(t, cli.Decoder().Decode(&hello))
+
+		// close the server's cbor decoder's io pipe
+		assert.NoError(t, stdinReader.Close())
+	}()
+
+	wg.Wait()
+	assert.Error(t, test_error)
+}
+
+func TestProtocol_Error_Client_WorkStart(t *testing.T) {
+	// Induce error on client's (and server incidentally)
+	// start work message by closing the client's cbor
+	// encoder's io pipe, stdinWriter, before the client
+	// executes a step.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	wgcli := &sync.WaitGroup{}
+	wgcli.Add(1)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	var srvr_error error
+	var cli_error error
+	go func() {
+		defer wg.Done()
+		err := atp.RunATPServer(
+			ctx,
+			stdinReader,
+			stdoutWriter,
+			helloWorldSchema,
+		)
+		if err != nil {
+			srvr_error = err
+		}
+	}()
+
+	go func() {
+		defer wgcli.Done()
+		_, err := cli.ReadSchema()
+		assert.NoError(t, err)
+
+		// close client's cbor encoder's io pipe
+		assert.NoError(t, stdinWriter.Close())
+
+		_, _, err = cli.Execute(ctx, "hello-world", map[string]any{"name": "Arca Lot"})
+		if err != nil {
+			cli_error = err
+		}
+	}()
+	wgcli.Wait()
+
+	wg.Wait()
+	assert.Error(t, srvr_error)
+	assert.Error(t, cli_error)
+}
+
+func TestProtocol_Error_Client_WorkDone(t *testing.T) {
+	// Induce error on client cbor decoding of work done
+	// message by closing the client's cbor decoder's io pipe,
+	// stdoutReader, after the server decodes the start work
+	// message.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	srvr := newATPServer(channel{
+		Reader:  stdinReader,
+		Writer:  stdoutWriter,
+		Context: ctx,
+		cancel:  cancel,
+	},
+		log.NewTestLogger(t))
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	var srvr_error error
+	var cli_error error
+
+	go func() {
+		defer wg.Done()
+		req := atp.StartWorkMessage{}
+		err := srvr.decoder.Decode(&req)
+		if err != nil {
+			srvr_error = err
+		}
+
+		// close client's cbor decoder's io pipe
+		assert.NoError(t, stdoutReader.Close())
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, _, err := cli.Execute(
+			ctx, "hello-world", map[string]any{"name": "Arca Lot"})
+		if err != nil {
+			cli_error = err
+		}
+	}()
+
+	wg.Wait()
+	assert.NoError(t, srvr_error)
+	assert.Error(t, cli_error)
+}
+
+func TestProtocol_Error_Server_WorkDone(t *testing.T) {
+	// Induce server error when it cbor encodes the work done
+	// message by closing its encoder's io pipe, stdoutWriter,
+	// right before the client decodes the work done message
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer cancel()
+
+	cli := atp.NewClientWithLogger(channel{
+		Reader:  stdoutReader,
+		Writer:  stdinWriter,
+		Context: ctx,
+		cancel:  cancel,
+	}, log.NewTestLogger(t))
+
+	var srvr_error error
+	var cli_error error
+
+	go func() {
+		defer wg.Done()
+		err := atp.RunATPServer(
+			ctx,
+			stdinReader,
+			stdoutWriter,
+			helloWorldSchema,
+		)
+		if err != nil {
+			srvr_error = err
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err := cli.ReadSchema()
+		assert.NoError(t, err)
+
+		// close server's cbor encoder's io pipe
+		assert.NoError(t, stdoutWriter.Close())
+
+		err = cli.Encoder().Encode(atp.StartWorkMessage{
+			StepID: "hello-world",
+			Config: map[string]any{"name": "Arca Lot"},
+		})
+		if err != nil {
+			cli_error = err
+		}
+	}()
+
+	wg.Wait()
+	assert.NoError(t, cli_error)
+	assert.Error(t, srvr_error)
+}
+
+// serverChannel holds the methods to talking to an ATP server (plugin).
+type serverChannel interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+type atpServer struct {
+	channel serverChannel
+	decMode cbor.DecMode
+	logger  log.Logger
+	decoder *cbor.Decoder
+	encoder *cbor.Encoder
+}
+
+func newATPServer(
+	channel serverChannel,
+	logger log.Logger,
+) atpServer {
+	decMode, err := cbor.DecOptions{
+		ExtraReturnErrors: cbor.ExtraDecErrorUnknownField,
+	}.DecMode()
+	if err != nil {
+		panic(err)
+	}
+	if logger == nil {
+		logger = log.NewLogger(log.LevelDebug, log.NewNOOPLogger())
+	}
+	return atpServer{
+		channel,
+		decMode,
+		logger,
+		decMode.NewDecoder(channel),
+		cbor.NewEncoder(channel),
 	}
 }

--- a/atp/server.go
+++ b/atp/server.go
@@ -20,12 +20,18 @@ func RunATPServer( //nolint:funlen
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	workDone := make(chan struct{})
+	closed := false // If this becomes a problem, switch this out for an atomic bool.
 	go func() {
 		defer wg.Done()
 		select {
 		case <-ctx.Done():
+			// The context is closed! That means this was instructed to stop.
+			// First let the code know that it was closed so that it doesn't panic.
+			closed = true
+			// Now close the pipe that it gets input from.
 			_ = stdin.Close()
 		case <-workDone:
+			// Done, so let it move on to the deferred wg.Done
 		}
 	}()
 	var goroutineError error
@@ -33,44 +39,63 @@ func RunATPServer( //nolint:funlen
 		defer wg.Done()
 		defer close(workDone)
 
+		// Start by serializing the schema, since the protocol requires sending the schema on the hello message.
 		serializedSchema, err := s.SelfSerialize()
 		if err != nil {
 			goroutineError = err
 			panic(goroutineError)
 		}
 
+		// The ATP protocol uses CBOR.
 		cborStdin := cbor.NewDecoder(stdin)
 		cborStdout := cbor.NewEncoder(stdout)
 
+		if closed { // Stop if closed.
+			return
+		}
+
+		// First, the start message, which is just an empty message.
 		var empty any
-		if err := cborStdin.Decode(&empty); err != nil {
+		if err := cborStdin.Decode(&empty); err != nil && !closed {
 			goroutineError = fmt.Errorf("failed to CBOR-decode start output message (%w)", err)
 			panic(goroutineError)
 		}
 
-		if err := cborStdout.Encode(helloMessage{1, serializedSchema}); err != nil {
+		// Next, send the hello message, which includes the version and schema.
+		if err := cborStdout.Encode(helloMessage{1, serializedSchema}); err != nil && !closed {
 			goroutineError = fmt.Errorf("failed to CBOR-encode schema (%w)", err)
 			panic(goroutineError)
 		}
 
+		// Now, get the work message that dictates which step to run and the config info.
 		req := startWorkMessage{}
-		if err := cborStdin.Decode(&req); err != nil {
-			goroutineError = fmt.Errorf("failed to CBOR-decode message (%w)", err)
+		if err := cborStdin.Decode(&req); err != nil && !closed {
+			goroutineError = fmt.Errorf("failed to CBOR-decode start work message (%w)", err)
 			panic(goroutineError)
+		}
+		if closed { // Stop if closed.
+			return
 		}
 		outputID, outputData, err := s.Call(req.StepID, req.Config)
 		if err != nil {
 			panic(err)
 		}
+		if closed { // Stop if closed.
+			return
+		}
+
+		// Lastly, send the work done message.
 		if err := cborStdout.Encode(workDoneMessage{
 			outputID,
 			outputData,
 			"",
-		}); err != nil {
+		}); err != nil && !closed {
 			goroutineError = fmt.Errorf("failed to encode CBOR response (%w)", err)
 			panic(goroutineError)
 		}
 	}()
+
+	// Keep running until both goroutines are done
 	wg.Wait()
 	return goroutineError
 }

--- a/atp/server.go
+++ b/atp/server.go
@@ -20,11 +20,11 @@ func RunATPServer( //nolint:funlen
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	workDone := make(chan error, 1)
-	var work_error error
+	var workError error
 	go func() {
 		defer wg.Done()
 		select {
-		case work_error = <-workDone:
+		case workError = <-workDone:
 			_ = stdin.Close()
 		case <-ctx.Done():
 			// Now close the pipe that it gets input from.
@@ -70,7 +70,7 @@ func RunATPServer( //nolint:funlen
 			return
 		}
 
-		outputID, outputData, err := s.Call(req.StepID, req.Config)
+		outputID, outputData, err := s.Call(ctx, req.StepID, req.Config)
 		if err != nil {
 			workDone <- err
 			return
@@ -93,5 +93,5 @@ func RunATPServer( //nolint:funlen
 
 	// Keep running until both goroutines are done
 	wg.Wait()
-	return work_error
+	return workError
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.18
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0
+	go.arcalot.io/assert v1.3.0
 	go.arcalot.io/log/v2 v2.0.0
+	golang.org/x/sync v0.2.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.arcalot.io/assert v1.3.0 h1:+uQex4s9gezATpTyFxUY5dlAcrwI1Me5fSmdcydGHho=
+go.arcalot.io/assert v1.3.0/go.mod h1:Xy3ScX0p9IMY89gdsgexOKxnmDr0nGHG9dV7p8Uxg7w=
 go.arcalot.io/log/v2 v2.0.0 h1:mbmsWDVBXZNWrDzUh5JLzeGCQ59kTuMFs+pyfJGc1hk=
 go.arcalot.io/log/v2 v2.0.0/go.mod h1:1V8jnFIIGwh2CtcGkHNOmy1nCo7LbazQNkUcnKYNMn4=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,6 +1,9 @@
 package schema
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Schema is a collection of steps supported by a plugin.
 type Schema[S Step] interface {
@@ -71,6 +74,7 @@ type CallableSchema struct {
 }
 
 func (s CallableSchema) Call(
+	ctx context.Context,
 	stepID string,
 	serializedInputData any,
 ) (
@@ -88,7 +92,7 @@ func (s CallableSchema) Call(
 	if err != nil {
 		return "", nil, InvalidInputError{err}
 	}
-	outputID, unserializedOutput, err := step.Call(unserializedInputData)
+	outputID, unserializedOutput, err := step.Call(ctx, unserializedInputData)
 	if err != nil {
 		return outputID, nil, err
 	}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"testing"
 
 	"go.flow.arcalot.io/pluginsdk/schema"
@@ -15,7 +16,8 @@ func TestSchemaCall(t *testing.T) {
 		"name": "Arca Lot",
 	}
 
-	outputID, outputData, err := schemaTestSchema.Call("hello", data)
+	ctx := context.Background()
+	outputID, outputData, err := schemaTestSchema.Call(ctx, "hello", data)
 	assertNoError(t, err)
 	assertEqual(t, outputID, "success")
 	typedData := outputData.(map[string]any)

--- a/schema/step_test.go
+++ b/schema/step_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -86,14 +87,15 @@ var testStepSchema = schema.NewCallableStep(
 	stepTestHandler,
 )
 
-func stepTestHandler(input stepTestInputData) (string, any) {
+func stepTestHandler(_ context.Context, input stepTestInputData) (string, any) {
 	return "success", stepTestSuccessOutput{
 		Message: fmt.Sprintf("Hello, %s!", input.Name),
 	}
 }
 
 func TestStepExecution(t *testing.T) {
-	outputID, outputData, err := testStepSchema.Call(stepTestInputData{Name: "Arca Lot"})
+	ctx := context.Background()
+	outputID, outputData, err := testStepSchema.Call(ctx, stepTestInputData{Name: "Arca Lot"})
 	assertNoError(t, err)
 	assertEqual(t, outputID, "success")
 	assertEqual(t, outputData.(stepTestSuccessOutput).Message, "Hello, Arca Lot!")


### PR DESCRIPTION
This PR improves how the code handles being terminated/closed early.

This issue was first found when we created a test deployer. With the test deployer, instead of running a plugin in a container then terminating it, it runs within the same process, so problems effect the main process.

## Changes introduced with this PR

The current design is on close, it sets a boolean, then closes the connection.
When the connection is closed, the encoder/decoder will throw an error, but it now checks the bool to see if it's intended, and only error out when it isn't.

There could theoretically be better designs out there. Let me know if there are any better simple designs that make it stop early when it is terminated.

This PR will be in a draft until the test cases are added.
We'll merge with a merge commit (likely) to preserve the blame authorship of both me and Matt.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).