### PR TITLE
Added client done message

### DIFF
--- a/atp/protocol.go
+++ b/atp/protocol.go
@@ -19,8 +19,9 @@ type StartWorkMessage struct {
 
 // All messages that can be contained in a RuntimeMessage struct.
 const (
-	MessageTypeWorkDone uint32 = 1
-	MessageTypeSignal   uint32 = 2
+	MessageTypeWorkDone   uint32 = 1
+	MessageTypeSignal     uint32 = 2
+	MessageTypeClientDone uint32 = 3
 )
 
 type RuntimeMessage struct {
@@ -47,4 +48,8 @@ type signalMessage struct {
 
 func (s signalMessage) ToInput() schema.Input {
 	return schema.Input{ID: s.SignalID, InputData: s.Data}
+}
+
+type clientDoneMessage struct {
+	// Empty for now.
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR just improves the ATP protocol by adding a client done message to not leave the other end of the connection hanging (which results in an error).
To facilitate this, it listens to both work done and received signals, and takes care of whatever ends up there first. This makes it so when the work done message is sent, it's able to get the done channel message immediately, so it can send the client done message before the connection is closed.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).