### PR TITLE
Fix ref being validated in object schema

### DIFF
--- a/schema/object_test.go
+++ b/schema/object_test.go
@@ -426,10 +426,18 @@ func TestTypedObjectSchema_Any(t *testing.T) {
 	assert.Error(t, err)
 }
 
+var testStructScope = schema.NewScopeSchema(&testStructSchema.ObjectSchema)
+
 func TestObjectSchema_ValidateCompatibility(t *testing.T) {
 	// Schema validation
 	assert.NoError(t, testStructSchema.ValidateCompatibility(testStructSchema))
 	assert.Error(t, testStructSchema.ValidateCompatibility(testOptionalFieldSchema)) // Not the same
+	// Schema validation with ref
+	objectTestRef := schema.NewRefSchema("testStruct", nil)
+	objectTestRef.ApplyScope(testStructScope)
+	assert.NoError(t, objectTestRef.ValidateCompatibility(testStructSchema))
+	assert.NoError(t, testStructSchema.ValidateCompatibility(objectTestRef))
+
 	// map verification
 	validData := map[string]any{
 		"Field1": 42,


### PR DESCRIPTION
## Changes introduced with this PR

This just fixes a ref schema being passed into an object schema for validity validation.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).