### PR TITLE
Function support

### DIFF
--- a/schema/function.go
+++ b/schema/function.go
@@ -1,0 +1,190 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type Function interface {
+	ID() string
+	Parameters() []Type
+	Output() Type
+	Display() Display
+}
+
+type CallableFunction interface {
+	Function
+	ToFunctionSchema() *FunctionSchema
+	Call(arguments []any) (any, error)
+}
+
+func NewCallableFunction(
+	id string,
+	inputs []Type,
+	output Type,
+	display Display,
+	handler any,
+) (CallableFunction, error) {
+	parsedHandler := reflect.ValueOf(handler)
+	// Validate the input types match the provided ones.
+	specifiedParams := len(inputs)
+	actualParams := parsedHandler.Type().NumIn()
+	if specifiedParams != actualParams {
+		return nil, fmt.Errorf(
+			"parameter inputs do not match handler inputs. handler has %d, expected %d",
+			actualParams, specifiedParams)
+	}
+	for i := 0; i < len(inputs); i++ {
+		expectedType := inputs[i].ReflectedType()
+		handlerType := parsedHandler.Type().In(i)
+		if expectedType != handlerType {
+			return nil, fmt.Errorf(
+				"type mismatch for parameter at index %d. handler has %v, inputs specifies %v",
+				i, handlerType, expectedType)
+		}
+	}
+	// Validate the output type
+	returnCount := parsedHandler.Type().NumOut()
+	if output == nil {
+		if returnCount > 1 {
+			return nil, fmt.Errorf("parameter output is nil, meaning it's a void function, or a function with just an error return, but got %d return types", returnCount)
+		} else if returnCount == 1 {
+			// Validate that it's just an error return
+			returnTypeName := parsedHandler.Type().Out(0).Name()
+			if returnTypeName != "error" {
+				return nil, fmt.Errorf("expected void or error return, but got %s", returnTypeName)
+			}
+		}
+	} else {
+		if returnCount > 2 || returnCount < 1 {
+			return nil, fmt.Errorf("expected handler to have one return, or one plus an error return, but got %d return types", returnCount)
+		} else {
+			// Validate the return type
+			expectedType := output.ReflectedType()
+			handlerType := parsedHandler.Type().Out(0)
+			if expectedType != handlerType {
+				return nil, fmt.Errorf("mismatched return type. expected %s, handler has %s", expectedType, handlerType)
+			}
+			// Validate error return, if applicable.
+			if returnCount == 2 && parsedHandler.Type().Out(1).Name() != "error" {
+				return nil, fmt.Errorf("expected additional return type to be an error return, but got %s", parsedHandler.Type().Out(1).Name())
+			}
+		}
+	}
+	return &CallableFunctionSchema{
+		IDValue:      id,
+		InputsValue:  inputs,
+		OutputValue:  output,
+		DisplayValue: display,
+		Handler:      parsedHandler,
+	}, nil
+}
+
+type FunctionSchema struct {
+	IDValue      string  `json:"id"`
+	InputsValue  []Type  `json:"inputs"`
+	OutputValue  Type    `json:"output"`
+	DisplayValue Display `json:"display"`
+}
+
+func (f FunctionSchema) ID() string {
+	return f.IDValue
+}
+
+func (f FunctionSchema) Parameters() []Type {
+	return f.InputsValue
+}
+
+func (f FunctionSchema) Output() Type {
+	return f.OutputValue
+}
+
+func (f FunctionSchema) Display() Display {
+	return f.DisplayValue
+}
+
+type CallableFunctionSchema struct {
+	IDValue      string  `json:"id"`
+	InputsValue  []Type  `json:"inputs"`
+	OutputValue  Type    `json:"output"`
+	DisplayValue Display `json:"display"`
+	// Should be a function call with any amount of parameters, and 0, 1 (err or data),
+	// or two return types (err and data).
+	// Params should match types in InputsValue.
+	// Return types should match OutputValue, or not be there if nil. Plus may have one addition return type: error.
+	Handler reflect.Value
+}
+
+func (s CallableFunctionSchema) ID() string {
+	return s.IDValue
+}
+func (s CallableFunctionSchema) Parameters() []Type {
+	return s.InputsValue
+}
+func (s CallableFunctionSchema) Output() Type {
+	return s.OutputValue
+}
+func (s CallableFunctionSchema) Display() Display {
+	return s.DisplayValue
+}
+func (s CallableFunctionSchema) ToFunctionSchema() *FunctionSchema {
+	return &FunctionSchema{
+		IDValue:      s.IDValue,
+		InputsValue:  s.Parameters(),
+		OutputValue:  s.OutputValue,
+		DisplayValue: s.DisplayValue,
+	}
+}
+func (s CallableFunctionSchema) Call(arguments []any) (any, error) {
+	gotArgs := len(arguments)
+	expectedArgs := s.Handler.Type().NumIn()
+	if gotArgs != expectedArgs {
+		return nil, fmt.Errorf(
+			"incorrect number of args sent to function with ID '%s'. Expected %d, got %d",
+			s.ID(),
+			expectedArgs,
+			gotArgs,
+		)
+	}
+	// Convert to reflect values
+	args := make([]reflect.Value, gotArgs)
+	for i := 0; i < gotArgs; i++ {
+		args[i] = reflect.ValueOf(arguments[i])
+	}
+	result := s.Handler.Call(args)
+	gotReturns := len(result)
+	expectedReturnVals := 0
+	if s.Output() != nil {
+		expectedReturnVals = 1
+	}
+	// Validate return types
+	switch {
+	case expectedReturnVals == gotReturns:
+		// Got expected return with no error return
+		if expectedReturnVals == 0 {
+			return nil, nil
+		} else {
+			return result[0].Interface(), nil
+		}
+	case expectedReturnVals+1 == gotReturns:
+		errorVal := result[expectedReturnVals]
+		if !errorVal.IsNil() {
+			err, isError := errorVal.Interface().(error)
+			if !isError {
+				return nil, fmt.Errorf("error return val isn't an error '%w'", err)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("function returned error: %w", err)
+			}
+		}
+		// Expected return plus error return
+		if expectedReturnVals == 0 {
+			return nil, nil
+		} else {
+			return result[0].Interface(), nil
+		}
+	default:
+		return nil, fmt.Errorf("unexpected return count. Expected %d or %d, got %d",
+			expectedReturnVals, expectedReturnVals+1, gotReturns)
+	}
+}

--- a/schema/function.go
+++ b/schema/function.go
@@ -125,7 +125,7 @@ func NewDynamicCallableFunction(
 
 	switch {
 	case returnCount != 2:
-		return nil, fmt.Errorf("expected dynamic handler to have two returns, one any and one error, but got %d return types", returnCount)
+		return nil, fmt.Errorf("expected dynamic handler to have two returns, one with any type, and one with error type, but got %d return types", returnCount)
 	case parsedHandler.Type().Out(1).Name() != errorType:
 		return nil, fmt.Errorf("expected additional return type to be an error return, but got %s", parsedHandler.Type().Out(1).Name())
 	case parsedHandler.Type().Out(0).Kind() != reflect.Interface:
@@ -150,7 +150,7 @@ func validateInputTypeCompatibility(
 	actualParams := handler.Type().NumIn()
 	if specifiedParams != actualParams {
 		return fmt.Errorf(
-			"parameter inputs do not match handler inputs. handler has %d, expected %d",
+			"parameter input counts do not match handler inputs. handler has %d, expected %d",
 			actualParams, specifiedParams)
 	}
 	for i := 0; i < specifiedParams; i++ {
@@ -158,8 +158,8 @@ func validateInputTypeCompatibility(
 		handlerType := handler.Type().In(i)
 		if expectedType != handlerType {
 			return fmt.Errorf(
-				"type mismatch for parameter at index %d. handler has %v, inputs specifies %v",
-				i, handlerType, expectedType)
+				"type mismatch for parameter at index %d. handler has %v, inputs schema at index %d specifies %v",
+				i, handlerType, i, expectedType)
 		}
 	}
 	return nil
@@ -213,8 +213,8 @@ type CallableFunctionSchema struct {
 	StaticOutputValue Type    `json:"output"`
 	DisplayValue      Display `json:"display"`
 	// A callable function whose parameters (if any) match the type schema specified in InputsValue,
-	// and whose return value type matches DefaultReturnValue, the return type from DynamicTypeHandler,
-	// or is void if both DefaultReturnValue and DynamicTypeHandler are nil.
+	// and whose return value type matches StaticOutputValue, the return type from DynamicTypeHandler,
+	// or is void if both StaticOutputValue and DynamicTypeHandler are nil.
 	// The handler may also return an error type.
 	Handler reflect.Value
 	// Returns the output type based on the input type. For advanced use cases. Cannot be void.

--- a/schema/function.go
+++ b/schema/function.go
@@ -221,15 +221,16 @@ func (f FunctionSchema) String() string {
 }
 
 func getReturnTypeString(returnType Type, hasError bool) string {
-	if returnType != nil {
+	switch {
+	case returnType != nil:
 		if hasError {
 			return "(" + string(returnType.TypeID()) + ", error)"
 		} else {
 			return string(returnType.TypeID())
 		}
-	} else if hasError {
+	case hasError:
 		return "error"
-	} else {
+	default:
 		return "void"
 	}
 }

--- a/schema/function.go
+++ b/schema/function.go
@@ -10,6 +10,7 @@ type Function interface {
 	Parameters() []Type
 	Output([]Type) (Type, error)
 	Display() Display
+	String() string
 }
 
 type CallableFunction interface {
@@ -145,6 +146,23 @@ func (f FunctionSchema) Display() Display {
 	return f.DisplayValue
 }
 
+func (f FunctionSchema) String() string {
+	result := f.ID() + "("
+	for i := 0; i < len(f.Parameters()); i++ {
+		if i != 0 {
+			result += ", "
+		}
+		result += string(f.Parameters()[i].TypeID())
+	}
+	result += ") "
+	if f.OutputValue != nil {
+		result += string(f.OutputValue.TypeID())
+	} else {
+		result += "void"
+	}
+	return result
+}
+
 type CallableFunctionSchema struct {
 	IDValue            string  `json:"id"`
 	InputsValue        []Type  `json:"inputs"`
@@ -162,9 +180,11 @@ type CallableFunctionSchema struct {
 func (s CallableFunctionSchema) ID() string {
 	return s.IDValue
 }
+
 func (s CallableFunctionSchema) Parameters() []Type {
 	return s.InputsValue
 }
+
 func (s CallableFunctionSchema) Output(inputType []Type) (Type, error) {
 	if s.DynamicTypeHandler == nil {
 		return s.DefaultOutputValue, nil
@@ -172,9 +192,30 @@ func (s CallableFunctionSchema) Output(inputType []Type) (Type, error) {
 		return s.DynamicTypeHandler(inputType)
 	}
 }
+
 func (s CallableFunctionSchema) Display() Display {
 	return s.DisplayValue
 }
+
+func (f CallableFunctionSchema) String() string {
+	result := f.ID() + "("
+	for i := 0; i < len(f.Parameters()); i++ {
+		if i != 0 {
+			result += ", "
+		}
+		result += string(f.Parameters()[i].TypeID())
+	}
+	result += ") "
+	if f.DynamicTypeHandler != nil {
+		result += "dynamic"
+	} else if f.DefaultOutputValue != nil {
+		result += string(f.DefaultOutputValue.TypeID())
+	} else {
+		result += "void"
+	}
+	return result
+}
+
 func (s CallableFunctionSchema) ToFunctionSchema() (*FunctionSchema, error) {
 	if s.DynamicTypeHandler != nil && s.DefaultOutputValue == nil {
 		return nil, fmt.Errorf(

--- a/schema/function_test.go
+++ b/schema/function_test.go
@@ -360,6 +360,22 @@ func TestNewDynamicFunction_Simple(t *testing.T) {
 	assert.Equals(t, result, 5)
 }
 
+func TestNewDynamicFunction_WrongReturnType(t *testing.T) {
+	_, err := schema.NewDynamicCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		func() (int, error) {
+			return 5, nil
+		},
+		func(inputType []schema.Type) (schema.Type, error) {
+			return schema.NewIntSchema(nil, nil, nil), nil
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 'any' return type for handler, but got int")
+}
+
 func TestNewDynamicFunction_1Param(t *testing.T) {
 	simpleFunc, err := schema.NewDynamicCallableFunction(
 		"test",

--- a/schema/function_test.go
+++ b/schema/function_test.go
@@ -1,0 +1,338 @@
+package schema_test
+
+import (
+	"fmt"
+	"go.arcalot.io/assert"
+	"go.flow.arcalot.io/pluginsdk/schema"
+	"reflect"
+	"testing"
+)
+
+// Simple, no input or output.
+func TestCallableFunctionSchema_Simple(t *testing.T) {
+	called := false
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		nil,
+		func() {
+			called = true
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equals(t, called, false)
+	result, err := simpleFunc.Call([]any{})
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+	assert.Equals(t, called, true)
+}
+
+// Simple, with one input.
+func TestCallableFunctionSchema_Simple1Param(t *testing.T) {
+	passedInVal := ""
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{schema.NewStringSchema(nil, nil, nil)},
+		nil,
+		nil,
+		func(test string) {
+			passedInVal = test
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{"a"})
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+	assert.Equals(t, passedInVal, "a")
+}
+
+// Simple, with no input, and only error out.
+func TestCallableFunctionSchema_SimpleWithNilErr(t *testing.T) {
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		nil,
+		func() error {
+			return nil
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{})
+	// No result or error
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// One input, nil error output.
+func TestCallableFunctionSchema_1ParamWithNilErr(t *testing.T) {
+	passedInVal := ""
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{schema.NewStringSchema(nil, nil, nil)},
+		nil,
+		nil,
+		func(test string) error {
+			passedInVal = test
+			return nil
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{"a"})
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+	// Validate that the schema.Type got passed in properly.
+	assert.Equals(t, passedInVal, "a")
+}
+
+// Simple, with error out.
+func TestCallableFunctionSchema_SimpleWithErr(t *testing.T) {
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		nil,
+		func() error {
+			return fmt.Errorf("this is an error")
+		},
+	)
+	assert.NoError(t, err)
+	_, err = simpleFunc.Call([]any{})
+	// There should be an error from the function. Validate that it's the correct one.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "this is an error")
+}
+
+// Simple, one output.
+func TestCallableFunctionSchema_OneReturn(t *testing.T) {
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		schema.NewStringSchema(nil, nil, nil),
+		nil,
+		func() string {
+			return "a"
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{})
+	// There should be an error. Validate that it's the correct one.
+	assert.NoError(t, err)
+	assert.InstanceOf[string](t, result)
+	assert.Equals(t, result.(string), "a")
+}
+
+// Multi-param, with int output.
+func TestCallableFunctionSchema_MultiParam(t *testing.T) {
+	simpleIntSchema := schema.NewIntSchema(nil, nil, nil)
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{simpleIntSchema, simpleIntSchema, simpleIntSchema, simpleIntSchema, simpleIntSchema, simpleIntSchema},
+		simpleIntSchema,
+		nil,
+		func(a int64, b int64, c int64, d int64, e int64, f int64) int64 {
+			return a * b * c * d * e * f
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)})
+	assert.NoError(t, err)
+	// Validate that the schema.Type got passed in properly.
+	assert.Equals[int64](t, result.(int64), int64(720))
+}
+
+// Multi-param, with int output.
+func TestCallableFunctionSchema_MultiParamWithNilErr(t *testing.T) {
+	simpleIntSchema := schema.NewIntSchema(nil, nil, nil)
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{simpleIntSchema, simpleIntSchema, simpleIntSchema},
+		simpleIntSchema,
+		nil,
+		func(a int64, b int64, c int64) (int64, error) {
+			return a * b * c, nil
+		},
+	)
+	assert.NoError(t, err)
+	result, err := simpleFunc.Call([]any{int64(1), int64(2), int64(3)})
+	assert.NoError(t, err)
+	// Validate that the schema.Type got passed in properly.
+	assert.Equals[int64](t, result.(int64), int64(6))
+}
+
+// Multi-param, with int output.
+func TestCallableFunctionSchema_Err_MultiParamWithErr(t *testing.T) {
+	simpleIntSchema := schema.NewIntSchema(nil, nil, nil)
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{simpleIntSchema, simpleIntSchema, simpleIntSchema},
+		simpleIntSchema,
+		nil,
+		func(a int64, b int64, c int64) (int64, error) {
+			return a * b * c, fmt.Errorf("this is an error")
+		},
+	)
+	assert.NoError(t, err)
+	_, err = simpleFunc.Call([]any{int64(1), int64(2), int64(3)})
+	// There should be an error. Validate that it's the correct one.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "this is an error")
+}
+
+func TestCallableFunctionSchema_Err_TestIncorrectNumArgs(t *testing.T) {
+	simpleIntSchema := schema.NewIntSchema(nil, nil, nil)
+	simpleFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{simpleIntSchema, simpleIntSchema, simpleIntSchema}, // Three params
+		simpleIntSchema,
+		nil,
+		func(a int64, b int64, c int64) (int64, error) { // Three params
+			return a * b * c, nil
+		},
+	)
+	assert.NoError(t, err)
+	_, err = simpleFunc.Call([]any{int64(1), int64(2)}) // Two args specified here
+	// There should be an error. Validate that it's the correct one.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incorrect number of args")
+}
+
+// The following test requires bypassing the validation provided in NewCallableFunction.
+func TestCallableFunctionSchema_Err_CallWrongErrorReturn(t *testing.T) {
+	callable := schema.CallableFunctionSchema{
+		IDValue:      "test",
+		InputsValue:  []schema.Type{},
+		OutputValue:  nil, // No return specified here, so only zero returns, or an error return is allowed.
+		DisplayValue: nil,
+		Handler: reflect.ValueOf(func() any { // Non-error return schema.Type here
+			return 5
+		}),
+	}
+	_, err := callable.Call(make([]any, 0))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error return val isn't an error")
+}
+
+// The following test requires bypassing the validation provided in NewCallableFunction.
+func TestCallableFunctionSchema_Err_CallWrongReturnCount(t *testing.T) {
+	callable := schema.CallableFunctionSchema{
+		IDValue:      "test",
+		InputsValue:  []schema.Type{},
+		OutputValue:  nil, // No returns specified here
+		DisplayValue: nil,
+		Handler: reflect.ValueOf(func() (any, any, any) { // Three returns specified here
+			return 0, 0, 0
+		}),
+	}
+	_, err := callable.Call(make([]any, 0))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected return count")
+}
+
+// Test the input validation.
+func TestNewCallableFunction_Err_MismatchedParamCount(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0), // No params specified here
+		nil,
+		nil,
+		func(int, int) {}, // Two params specified here
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parameter inputs do not match handler inputs")
+}
+
+func TestNewCallableFunction_Err_MismatchedParamType(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{schema.NewStringSchema(nil, nil, nil)}, // String specified here
+		nil,
+		nil,
+		func(int) {}, // Int specified here, mismatched
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "schema.Type mismatch for parameter")
+}
+
+func TestNewCallableFunction_Err_NilReturnMismatchedReturnCount(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		nil,
+		func() (int, error) { // Zero returns specified. That's wrong.
+			return 0, nil
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parameter output is nil, meaning it's a void function")
+}
+
+func TestNewCallableFunction_Err_NilReturnNotError(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		nil,
+		nil,
+		func() int { // This isn't a valid return given the schema. Should be error or void.
+			return 0
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected void or error return")
+}
+
+func TestNewCallableFunction_Err_NotEnoughReturns(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		schema.NewStringSchema(nil, nil, nil), // String
+		nil,
+		func() {}, // No returns here. We specified string earlier.
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected handler to have one return")
+}
+
+func TestNewCallableFunction_Err_MismatchedReturnType(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		schema.NewStringSchema(nil, nil, nil), // String here
+		nil,
+		func() int { // Int here, mismatched
+			return 0
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatched return schema.Type")
+}
+
+func TestNewCallableFunction_Err_TooManyReturns(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		schema.NewStringSchema(nil, nil, nil),
+		nil,
+		func() (string, string, error) { // Too may returns here
+			return "", "", nil
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected handler to have one return")
+}
+
+func TestNewCallableFunction_Err_ReturnNotError(t *testing.T) {
+	_, err := schema.NewCallableFunction(
+		"test",
+		make([]schema.Type, 0),
+		schema.NewStringSchema(nil, nil, nil),
+		nil,
+		func() (string, string) { // Incorrect return schema.Type here
+			return "", ""
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected additional return schema.Type to be an error return")
+}

--- a/schema/function_test.go
+++ b/schema/function_test.go
@@ -264,7 +264,7 @@ func TestNewCallableFunction_Err_MismatchedParamType(t *testing.T) {
 }
 
 func TestNewCallableFunction_Err_NilReturnMismatchedReturnCount(t *testing.T) {
-	// In this case, the schema will specify zeo returns, when the handler will have both a return type an en error return
+	// In this case, the schema will specify zero returns, when the handler will have both a return type an en error return
 	_, err := schema.NewCallableFunction(
 		"test",
 		make([]schema.Type, 0),
@@ -546,7 +546,7 @@ func TestFunctionToStringOneParamVoid(t *testing.T) {
 }
 
 func TestFunctionToStringToFunctionTwoParam(t *testing.T) {
-	oneParamVoidCallableFunction, err := schema.NewCallableFunction(
+	callableFunc, err := schema.NewCallableFunction(
 		"b",
 		[]schema.Type{
 			schema.NewStringSchema(nil, nil, nil),
@@ -557,14 +557,14 @@ func TestFunctionToStringToFunctionTwoParam(t *testing.T) {
 		func(a string, b int64) int64 { return 0 },
 	)
 	assert.NoError(t, err)
-	funcStr := oneParamVoidCallableFunction.String()
+	funcStr := callableFunc.String()
 	assert.Equals(t, funcStr, "b(string, integer) integer")
 
 	// Now the version in FunctionSchema instead of CallableFunction
-	oneParamVoidFunction, err := oneParamVoidCallableFunction.ToFunctionSchema()
+	funcSchema, err := callableFunc.ToFunctionSchema()
 	assert.NoError(t, err)
 
-	funcStr = oneParamVoidFunction.String()
+	funcStr = funcSchema.String()
 	assert.Equals(t, funcStr, "b(string, integer) integer")
 }
 

--- a/schema/function_test.go
+++ b/schema/function_test.go
@@ -247,7 +247,7 @@ func TestNewCallableFunction_Err_MismatchedParamCount(t *testing.T) {
 		func(int, int) {}, // Two params specified here
 	)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parameter inputs do not match handler inputs")
+	assert.Contains(t, err.Error(), "parameter input counts do not match handler inputs")
 }
 
 func TestNewCallableFunction_Err_MismatchedParamType(t *testing.T) {

--- a/schema/function_test.go
+++ b/schema/function_test.go
@@ -492,9 +492,7 @@ func TestNewDynamicFunction_SameType(t *testing.T) {
 			return a, nil
 		},
 		func(inputTypes []schema.Type) (schema.Type, error) {
-			if len(inputTypes) != 1 {
-				return nil, fmt.Errorf("expected 1 arg, got %d", len(inputTypes))
-			}
+			assert.Equals(t, len(inputTypes), 1)
 			return inputTypes[0], nil
 		},
 	)
@@ -556,9 +554,7 @@ func TestNewDynamicFunction_SliceOfSameType(t *testing.T) {
 			return result.Interface(), nil
 		},
 		func(inputTypes []schema.Type) (schema.Type, error) {
-			if len(inputTypes) != 1 {
-				return nil, fmt.Errorf("expected 1 arg, got %d", len(inputTypes))
-			}
+			assert.Equals(t, len(inputTypes), 1)
 			return schema.NewListSchema(inputTypes[0], nil, nil), nil
 		},
 	)


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds functions to the schema.

There are two main categories of functions. Statically typed and dynamically typed.
- The way that the dynamically typed functions are implemented mean that we still validate their type, but a little looser using a function that determines the type after the input parameters are passed in. 
- Dynamically typed functions allow functions that support more generic things, like creating an object with specific fields.
- The statically typed functions are validated strictly. You pass in the function handler, and it's validated at runtime.
- The allowed return types for a standard function may or may not include an error return. This error return is in addition to the single return specified by the schema, if present.

For examples on how this is used, see the expressions draft PR: https://github.com/arcalot/arcaflow-expressions/pull/16

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).