### PR TITLE
Improvements to Ref for Namespaced Scopes

### DIFF
--- a/schema/ref.go
+++ b/schema/ref.go
@@ -115,7 +115,7 @@ func (r *RefSchema) ApplyScope(scope Scope, namespace string) {
 	referencedObject, ok := objects[r.IDValue]
 	if !ok {
 		availableObjects := ""
-		for objectID, _ := range objects {
+		for objectID := range objects {
 			availableObjects += objectID + "\n"
 		}
 		panic(BadArgumentError{

--- a/schema/scope_test.go
+++ b/schema/scope_test.go
@@ -463,7 +463,9 @@ func TestApplyingExternalNamespace(t *testing.T) {
 			err = testData.ref.ValidateReferences()
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "missing its link")
+			assert.Equals(t, testData.ref.ObjectReady(), false)
 			testData.scope.ApplyScope(externalScope, "test-namespace")
+			assert.Equals(t, testData.ref.ObjectReady(), true)
 			// Now it's applied, so the error should be resolved.
 			// Outermost
 			assert.NoError(t, testData.scope.ValidateReferences())

--- a/schema/scope_test.go
+++ b/schema/scope_test.go
@@ -321,7 +321,7 @@ func TestApplyingExternalNamespace(t *testing.T) {
 	// The applied scope must be passed down to all of those types, validating
 	// that the scope gets applied down and that errors are propagated up.
 	refRefSchema := schema.NewNamespacedRefSchema("scopeTestObjectB", "test-namespace", nil)
-
+	assert.Equals(t, refRefSchema.Namespace(), "test-namespace")
 	refProperty := schema.NewPropertySchema(
 		refRefSchema,
 		nil,


### PR DESCRIPTION
## Changes introduced with this PR

I exposed some more info in Ref.
1. `Namespace` is now in the `Ref` interface.
2. `ObjectReady` is now exposed to gracefully handle potentially pre-scope-application code.
3. I exposed the available objects in the event of a panic due to invalid ID.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).