### PR TITLE
Export Helper Function

### DIFF
--- a/schema/object.go
+++ b/schema/object.go
@@ -342,7 +342,7 @@ func (o *ObjectSchema) validateStruct(data any) error {
 	return o.validateFieldInterdependencies(rawData)
 }
 
-func (o *ObjectSchema) convertToObjectSchema(typeOrData any) (Object, bool) {
+func ConvertToObjectSchema(typeOrData any) (Object, bool) {
 	// Try plain object schema
 	objectSchemaType, ok := typeOrData.(*ObjectSchema)
 	if ok {
@@ -412,7 +412,7 @@ func (o *ObjectSchema) validateRawCompatibility(typeOrData any) error {
 
 func (o *ObjectSchema) ValidateCompatibility(typeOrData any) error {
 	// Check if it's a schema. If it is, verify it. If not, verify it as data.
-	schemaType, ok := o.convertToObjectSchema(typeOrData)
+	schemaType, ok := ConvertToObjectSchema(typeOrData)
 	if ok {
 		// It's a schema, so see if the schema matches
 		return o.validateSchemaCompatibility(schemaType)

--- a/schema/object.go
+++ b/schema/object.go
@@ -342,38 +342,6 @@ func (o *ObjectSchema) validateStruct(data any) error {
 	return o.validateFieldInterdependencies(rawData)
 }
 
-func ConvertToObjectSchema(typeOrData any) (Object, bool) {
-	// Try plain object schema
-	objectSchemaType, ok := typeOrData.(*ObjectSchema)
-	if ok {
-		return objectSchemaType, true
-	}
-	// Next, try ref schema
-	refSchemaType, ok := typeOrData.(*RefSchema)
-	if ok {
-		return refSchemaType.GetObject(), true
-	}
-	// Next, try scope schema.
-	scopeSchemaType, ok := typeOrData.(*ScopeSchema)
-	if ok {
-		return scopeSchemaType.Objects()[scopeSchemaType.Root()], true
-	}
-	// Try getting the inlined ObjectSchema for objects, like TypedObjectSchema, that do that.
-	value := reflect.ValueOf(typeOrData)
-	if reflect.Indirect(value).Kind() == reflect.Struct {
-		field := reflect.Indirect(value).FieldByName("ObjectSchema")
-		if field.IsValid() {
-			fieldAsInterface := field.Interface()
-			objectType, ok2 := fieldAsInterface.(ObjectSchema)
-			if ok2 {
-				objectSchemaType = &objectType
-				ok = true
-			}
-		}
-	}
-	return objectSchemaType, ok
-}
-
 func (o *ObjectSchema) validateSchemaCompatibility(schemaType Object) error {
 	fieldData := map[string]any{}
 	// Validate IDs. This is important because the IDs should match.
@@ -682,6 +650,40 @@ func (a *AnyTypedObject[T]) SerializeType(data any) (any, error) {
 
 func (a *AnyTypedObject[T]) Any() TypedObject[any] {
 	return a
+}
+
+// ConvertToObjectSchema attempts to cast the given type or data to an
+// ObjectSchema. If successful it returns true, else it returns false.
+func ConvertToObjectSchema(typeOrData any) (Object, bool) {
+	// Try plain object schema
+	objectSchemaType, ok := typeOrData.(*ObjectSchema)
+	if ok {
+		return objectSchemaType, true
+	}
+	// Next, try ref schema
+	refSchemaType, ok := typeOrData.(*RefSchema)
+	if ok {
+		return refSchemaType.GetObject(), true
+	}
+	// Next, try scope schema.
+	scopeSchemaType, ok := typeOrData.(*ScopeSchema)
+	if ok {
+		return scopeSchemaType.Objects()[scopeSchemaType.Root()], true
+	}
+	// Try getting the inlined ObjectSchema for objects, like TypedObjectSchema, that do that.
+	value := reflect.ValueOf(typeOrData)
+	if reflect.Indirect(value).Kind() == reflect.Struct {
+		field := reflect.Indirect(value).FieldByName("ObjectSchema")
+		if field.IsValid() {
+			fieldAsInterface := field.Interface()
+			objectType, ok2 := fieldAsInterface.(ObjectSchema)
+			if ok2 {
+				objectSchemaType = &objectType
+				ok = true
+			}
+		}
+	}
+	return objectSchemaType, ok
 }
 
 func validateObjectIsStruct[T any]() {

--- a/schema/object.go
+++ b/schema/object.go
@@ -657,7 +657,7 @@ func (a *AnyTypedObject[T]) Any() TypedObject[any] {
 // If an ObjectSchema is found, it returns it.
 // If a RefSchema is found, it extracts the cached object schema the ref is referencing.
 // If a ScopeSchema is found, it extracts the root object schema.
-// Returns true if successful, false otherwise.
+// Returns the ObjectSchema and true if successful, otherwise nil and false.
 func ConvertToObjectSchema(typeOrData any) (Object, bool) {
 	// Try plain object schema
 	objectSchemaType, ok := typeOrData.(*ObjectSchema)

--- a/schema/object.go
+++ b/schema/object.go
@@ -674,7 +674,7 @@ func ConvertToObjectSchema(typeOrData any) (Object, bool) {
 	if ok {
 		return scopeSchemaType.Objects()[scopeSchemaType.Root()], true
 	}
-	// Try getting the inlined ObjectSchema for objects, like TypedObjectSchema, that do that.
+	// Try extracting the inlined ObjectSchema for types that have an ObjectSchema, like TypedObjectSchema.
 	value := reflect.ValueOf(typeOrData)
 	if reflect.Indirect(value).Kind() == reflect.Struct {
 		field := reflect.Indirect(value).FieldByName("ObjectSchema")

--- a/schema/object.go
+++ b/schema/object.go
@@ -652,7 +652,8 @@ func (a *AnyTypedObject[T]) Any() TypedObject[any] {
 	return a
 }
 
-// ConvertToObjectSchema attempts to cast the given type or data to an
+// ConvertToObjectSchema attempts to extract the given type or data from a
+// RefSchema or from the root of a ScopeSchema, and then cast it to an
 // ObjectSchema. If successful it returns true, else it returns false.
 func ConvertToObjectSchema(typeOrData any) (Object, bool) {
 	// Try plain object schema

--- a/schema/object.go
+++ b/schema/object.go
@@ -652,9 +652,12 @@ func (a *AnyTypedObject[T]) Any() TypedObject[any] {
 	return a
 }
 
-// ConvertToObjectSchema attempts to extract the given type or data from a
-// RefSchema or from the root of a ScopeSchema, and then cast it to an
-// ObjectSchema. If successful it returns true, else it returns false.
+// ConvertToObjectSchema attempts to extract an ObjectSchema from the input.
+//
+// If an ObjectSchema is found, it returns it.
+// If a RefSchema is found, it extracts the cached object schema the ref is referencing.
+// If a ScopeSchema is found, it extracts the root object schema.
+// Returns true if successful, false otherwise.
 func ConvertToObjectSchema(typeOrData any) (Object, bool) {
 	// Try plain object schema
 	objectSchemaType, ok := typeOrData.(*ObjectSchema)


### PR DESCRIPTION
## Changes introduced with this PR

Facilitate type casting schemas to `ObjectSchema` outside of the `pluginsdk` package.

- [X] export the function previously known as `convertToObjectSchema`
- [X] refactor `ConvertToObjectSchema` method as a package function

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).