### PR TITLE
Fix Channel Close Behavior

### DIFF
--- a/atp/client.go
+++ b/atp/client.go
@@ -213,7 +213,6 @@ func (c *client) handleStepComplete(runID string, receivedSignals chan schema.In
 		_, exists := c.runningSignalReceiveLoops[runID]
 		if exists {
 			delete(c.runningSignalReceiveLoops, runID)
-			close(receivedSignals)
 		}
 		c.mutex.Unlock()
 	}
@@ -227,13 +226,6 @@ func (c *client) Close() error {
 		return nil
 	}
 	c.done = true
-	// First, close channels that could send signals to the clients
-	// This ends the loop
-	for runID, signalChannel := range c.runningSignalReceiveLoops {
-		c.logger.Infof("Closing signal channel for run ID '%s'", runID)
-		delete(c.runningSignalReceiveLoops, runID)
-		close(signalChannel)
-	}
 	c.mutex.Unlock()
 	// Now tell the server we're done.
 	// Send the client done message


### PR DESCRIPTION
## Changes introduced with this PR

This PR lets the user be responsible for closing signal channel. This proposed design is the "correct" one. Golang specifically does not recommend that receivers close the channel, which is what was happening. And there was no way to reliably ensure that the channel was open on the sending side, leading to race conditions.

This was discovered while working on the engine. There were issues where I sent on a closed channel.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).