### PR TITLE
Use typed channels

### DIFF
--- a/atp/client.go
+++ b/atp/client.go
@@ -214,10 +214,7 @@ func (c *client) handleStepComplete(runID string, receivedSignals chan schema.In
 		// Remove from the map to ensure that the client.Close() method doesn't double-close it
 		c.mutex.Lock()
 		// Validate that it exists, since Close() could have been called early.
-		_, exists := c.runningSignalReceiveLoops[runID]
-		if exists {
-			delete(c.runningSignalReceiveLoops, runID)
-		}
+		delete(c.runningSignalReceiveLoops, runID)
 		c.mutex.Unlock()
 	}
 }

--- a/atp/client.go
+++ b/atp/client.go
@@ -75,7 +75,7 @@ func NewClientWithLogger(
 		cbor.NewEncoder(channel),
 		make(chan bool, 5), // Buffer to prevent deadlocks
 		make([]schema.Input, 0),
-		make(map[string]chan schema.Input),
+		make(map[string]chan<- schema.Input),
 		make(map[string]*executionEntry),
 		make(map[string]chan<- schema.Input),
 		sync.Mutex{},
@@ -107,7 +107,7 @@ type client struct {
 	encoder                          *cbor.Encoder
 	doneChannel                      chan bool
 	runningSteps                     []schema.Input
-	runningSignalReceiveLoops        map[string]chan schema.Input   // Run ID to channel of signals to steps
+	runningSignalReceiveLoops        map[string]chan<- schema.Input // Run ID to channel of signals to steps
 	runningStepResultEntries         map[string]*executionEntry     // Run ID to results
 	runningStepEmittedSignalChannels map[string]chan<- schema.Input // Run ID to channel of signals emitted from steps
 	mutex                            sync.Mutex

--- a/atp/client.go
+++ b/atp/client.go
@@ -186,6 +186,7 @@ func (c *client) Execute(
 		// Handle signals to the step
 		if receivedSignals != nil {
 			c.wg.Add(1)
+			defer c.handleStepComplete(stepData.RunID)
 			go func() {
 				defer c.wg.Done()
 				c.executeWriteLoop(stepData.RunID, receivedSignals)
@@ -203,9 +204,6 @@ func (c *client) Execute(
 	}
 	c.logger.Debugf("Step '%s' started, waiting for response...", stepData.ID)
 
-	if receivedSignals != nil {
-		defer c.handleStepComplete(stepData.RunID)
-	}
 	return c.getResult(stepData, cborReader)
 }
 

--- a/atp/client.go
+++ b/atp/client.go
@@ -36,7 +36,7 @@ type Client interface {
 	// ReadSchema reads the schema from the ATP server.
 	ReadSchema() (*schema.SchemaSchema, error)
 	// Execute executes a step with a given context and returns the resulting output. Assumes you called ReadSchema first.
-	Execute(input schema.Input, receivedSignals chan schema.Input, emittedSignals chan<- schema.Input) ExecutionResult
+	Execute(input schema.Input, receivedSignals <-chan schema.Input, emittedSignals chan<- schema.Input) ExecutionResult
 	Close() error
 	Encoder() *cbor.Encoder
 	Decoder() *cbor.Decoder
@@ -165,7 +165,7 @@ func (c *client) validateVersion(serverVersion int64) error {
 
 func (c *client) Execute(
 	stepData schema.Input,
-	receivedSignals chan schema.Input,
+	receivedSignals <-chan schema.Input,
 	emittedSignals chan<- schema.Input,
 ) ExecutionResult {
 	c.logger.Debugf("Executing plugin step %s/%s...", stepData.RunID, stepData.ID)
@@ -271,7 +271,7 @@ func (c *client) getRunningStepIDs() string {
 // Listen for received signals, and send them over ATP if available.
 func (c *client) executeWriteLoop(
 	runID string,
-	receivedSignals chan schema.Input,
+	receivedSignals <-chan schema.Input,
 ) {
 	c.mutex.Lock()
 	if c.done {

--- a/atp/client.go
+++ b/atp/client.go
@@ -209,12 +209,12 @@ func (c *client) Execute(
 	return c.getResult(stepData, cborReader)
 }
 
-// handleStepComplete is the deferred function that will handle closing of the received channel.
+// handleStepComplete performs cleanup actions for a step when its execution is
+// complete.  Currently, this consists solely of removing its entry from the
+// map of channels used to send it signals.
 func (c *client) handleStepComplete(runID string) {
 	c.logger.Infof("Closing signal channel for finished step")
-	// Remove from the map to ensure that the client.Close() method doesn't double-close it
 	c.mutex.Lock()
-	// Validate that it exists, since Close() could have been called early.
 	delete(c.runningSignalReceiveLoops, runID)
 	c.mutex.Unlock()
 }

--- a/atp/client.go
+++ b/atp/client.go
@@ -203,20 +203,20 @@ func (c *client) Execute(
 	}
 	c.logger.Debugf("Step '%s' started, waiting for response...", stepData.ID)
 
-	defer c.handleStepComplete(stepData.RunID, receivedSignals)
+	if receivedSignals != nil {
+		defer c.handleStepComplete(stepData.RunID)
+	}
 	return c.getResult(stepData, cborReader)
 }
 
 // handleStepComplete is the deferred function that will handle closing of the received channel.
-func (c *client) handleStepComplete(runID string, receivedSignals chan schema.Input) {
-	if receivedSignals != nil {
-		c.logger.Infof("Closing signal channel for finished step")
-		// Remove from the map to ensure that the client.Close() method doesn't double-close it
-		c.mutex.Lock()
-		// Validate that it exists, since Close() could have been called early.
-		delete(c.runningSignalReceiveLoops, runID)
-		c.mutex.Unlock()
-	}
+func (c *client) handleStepComplete(runID string) {
+	c.logger.Infof("Closing signal channel for finished step")
+	// Remove from the map to ensure that the client.Close() method doesn't double-close it
+	c.mutex.Lock()
+	// Validate that it exists, since Close() could have been called early.
+	delete(c.runningSignalReceiveLoops, runID)
+	c.mutex.Unlock()
 }
 
 // Close Tells the client that it's done, and can stop listening for more requests.


### PR DESCRIPTION
## Changes introduced with this PR

This is a follow-on to #96:  if the channel instances had been properly typed (to wit, as receive-only), it might not have been possible to close them in the first place (since [an attempt to close a receive-only channel results in an error](https://go.dev/ref/spec#Close)), and that might have alleviated some trouble.  So, this PR modifies the `Client.Execute()` interface (and its implementation and subroutines) to declare the `receivedSignals` parameter as a receive-only channel, so that its usage is clearer.

In the process of producing that change, it became apparent that we no longer need the `handleStepComplete()` function and the `runningSignalReceiveLoops` map, so these were removed, as well as the code supporting them.

This PR also includes three other sets of changes:
- The first picks lint (and fixes some real issues):
  - There were three places where we were using the `%w` formatting verb outside of the context of a `fmt.Errorf()` call:
    - one I fixed by changing it to `%v`; and,
    - two I fixed by factoring out the formatting, since it was being shared with logging.
  - There was a place where we were missing a formatting verb (it was typed as `'&s'`; I replaced it with `%q`).
  - And, there were a couple of other, minor lint complaints that I addressed.
- The second removes an existence check which is unneed post #96.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).