### PR TITLE
Allow oneof for any schemas

### DIFF
--- a/schema/any.go
+++ b/schema/any.go
@@ -67,10 +67,13 @@ func (a *AnySchema) ValidateCompatibility(typeOrData any) error {
 	case reflect.Map:
 		return nil
 	default:
+		// Schema is not a primitive, slice, or map type, so check the complex types
+		// Explicitly allow object schemas since their reflected type can be a struct if they are struct mapped.
 		switch typeOrData.(type) {
-		case *AnySchema, *OneOfSchema[int64], *OneOfSchema[string]:
+		case *AnySchema, *OneOfSchema[int64], *OneOfSchema[string], *ObjectSchema:
+			// These are the allowed values.
 		default:
-			// It's not an any schema, so error
+			// It's not an any schema or a type compatible with an any schema, so error
 			return &ConstraintError{
 				Message: fmt.Sprintf("unsupported schema type for 'any' type: %T", typeOrData),
 			}

--- a/schema/any.go
+++ b/schema/any.go
@@ -75,7 +75,7 @@ func (a *AnySchema) ValidateCompatibility(typeOrData any) error {
 		default:
 			// It's not an any schema or a type compatible with an any schema, so error
 			return &ConstraintError{
-				Message: fmt.Sprintf("unsupported schema type for 'any' type: %T", typeOrData),
+				Message: fmt.Sprintf("schema type `%T` cannot be used as an input for an 'any' type", typeOrData),
 			}
 		}
 		return nil

--- a/schema/any.go
+++ b/schema/any.go
@@ -67,12 +67,12 @@ func (a *AnySchema) ValidateCompatibility(typeOrData any) error {
 	case reflect.Map:
 		return nil
 	default:
-		// Check if it's an actual 'any' schema.
-		schemaType, ok := typeOrData.(*AnySchema)
-		if !ok {
+		switch typeOrData.(type) {
+		case *AnySchema, *OneOfSchema[int64], *OneOfSchema[string]:
+		default:
 			// It's not an any schema, so error
 			return &ConstraintError{
-				Message: fmt.Sprintf("unsupported schema type for 'any' type: %T", schemaType),
+				Message: fmt.Sprintf("unsupported schema type for 'any' type: %T", typeOrData),
 			}
 		}
 		return nil

--- a/schema/any_test.go
+++ b/schema/any_test.go
@@ -167,6 +167,7 @@ func TestAnyValidateCompatibility(t *testing.T) {
 		),
 	}
 	type someStruct struct {
+		//nolint:unused  // This is just for test purposes.
 		field1 int
 	}
 	objectSchema := schema.NewObjectSchema("some-id", properties)

--- a/schema/any_test.go
+++ b/schema/any_test.go
@@ -154,6 +154,23 @@ func TestAnyTypeReflectedType(t *testing.T) {
 
 func TestAnyValidateCompatibility(t *testing.T) {
 	s1 := schema.NewAnySchema()
+	properties := map[string]*schema.PropertySchema{
+		"field1": schema.NewPropertySchema(
+			schema.NewIntSchema(nil, nil, nil),
+			nil,
+			true,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		),
+	}
+	type someStruct struct {
+		field1 int
+	}
+	objectSchema := schema.NewObjectSchema("some-id", properties)
+	structMappedObjectSchema := schema.NewStructMappedObjectSchema[someStruct]("some-id", properties)
 
 	assert.NoError(t, s1.ValidateCompatibility(schema.NewAnySchema()))
 	assert.NoError(t, s1.ValidateCompatibility(schema.NewStringSchema(nil, nil, nil)))
@@ -170,5 +187,13 @@ func TestAnyValidateCompatibility(t *testing.T) {
 	assert.NoError(t, s1.ValidateCompatibility(map[string]any{}))
 	assert.NoError(t, s1.ValidateCompatibility(schema.NewStringEnumSchema(map[string]*schema.DisplayValue{})))
 	assert.NoError(t, s1.ValidateCompatibility(schema.NewIntEnumSchema(map[int64]*schema.DisplayValue{}, nil)))
-
+	assert.NoError(t, s1.ValidateCompatibility(objectSchema))
+	// Test struct mapped since it may have a different reflected type.
+	assert.NoError(t, s1.ValidateCompatibility(structMappedObjectSchema))
+	assert.NoError(t, s1.ValidateCompatibility(
+		schema.NewOneOfStringSchema[string](map[string]schema.Object{}, "id", false),
+	))
+	assert.NoError(t, s1.ValidateCompatibility(
+		schema.NewOneOfIntSchema[int64](map[int64]schema.Object{}, "id", false),
+	))
 }


### PR DESCRIPTION
## Changes introduced with this PR

Oneof schemas should behave acceptably when used. They should provide the data in a map format with the discriminator inlined.
This will allow oneof types to be inputted to the `wait_for` field.

If we need a type that doesn't permit oneof types, we could add more specific types.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).